### PR TITLE
Fix issue 745 Properly decode URL paths

### DIFF
--- a/extensions/servlet/src/com/google/inject/servlet/ServletDefinition.java
+++ b/extensions/servlet/src/com/google/inject/servlet/ServletDefinition.java
@@ -26,6 +26,8 @@ import com.google.inject.spi.ProviderInstanceBinding;
 import com.google.inject.spi.ProviderWithExtensionVisitor;
 
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.Collections;
 import java.util.Enumeration;
 import java.util.HashMap;
@@ -215,6 +217,14 @@ class ServletDefinition implements ProviderWithExtensionVisitor<ServletDefinitio
           // then pathinfo is null
           if ("".equals(pathInfo) && servletPathLength != 0) {
             pathInfo = null;
+          }
+
+          if (pathInfo != null) {
+            try {
+              pathInfo = new URI(pathInfo).getPath();
+            } catch (URISyntaxException e) {
+              // ugh, just leave it alone then
+            }
           }
 
           pathInfoComputed = true;

--- a/extensions/servlet/test/com/google/inject/servlet/ServletDefinitionPathsTest.java
+++ b/extensions/servlet/test/com/google/inject/servlet/ServletDefinitionPathsTest.java
@@ -131,6 +131,10 @@ public class ServletDefinitionPathsTest extends TestCase {
         "/.../h.thing");
     pathInfoWithServletStyleMatching("/path/my/h.thing", "/path", "*.thing", null, "/my/h.thing");
 
+    // Encoded URLs
+    pathInfoWithServletStyleMatching("/path/index%2B.html", "/path", "/*", "/index+.html", "");
+    pathInfoWithServletStyleMatching("/path/a%20file%20with%20spaces%20in%20name.html", "/path", "/*", "/a file with spaces in name.html", "");
+    pathInfoWithServletStyleMatching("/path/Tam%C3%A1s%20nem%20m%C3%A1s.html", "/path", "/*", "/Tamás nem más.html", "");
   }
 
   private void pathInfoWithServletStyleMatching(final String requestUri, final String contextPath,
@@ -227,6 +231,11 @@ public class ServletDefinitionPathsTest extends TestCase {
     // path
     pathInfoWithRegexMatching("/path/test.com/com.test.MyServletModule", "", "/path/[^/]+/(.*)",
         "com.test.MyServletModule", "/path/test.com/com.test.MyServletModule");
+
+    // Encoded URLs
+    pathInfoWithRegexMatching("/path/index%2B.html", "/path", "/(.)*", "/index+.html", "");
+    pathInfoWithRegexMatching("/path/a%20file%20with%20spaces%20in%20name.html", "/path", "/(.)*", "/a file with spaces in name.html", "");
+    pathInfoWithRegexMatching("/path/Tam%C3%A1s%20nem%20m%C3%A1s.html", "/path", "/(.)*", "/Tamás nem más.html", "");
   }
 
   public final void pathInfoWithRegexMatching(final String requestUri, final String contextPath,


### PR DESCRIPTION
Problem was that wrapped HttpServletRequest prepped by ServletDefinition used request methods that returns non-decoded path to craft pathInfo, that _must be_ decoded.

Issue
https://code.google.com/p/google-guice/issues/detail?id=745
